### PR TITLE
Add standoff mounting holes to display footprint

### DIFF
--- a/sensorstick/CustomLibrary.pretty/OLED-TH_L38.0-W12.0_HS91L02W2C01.kicad_mod
+++ b/sensorstick/CustomLibrary.pretty/OLED-TH_L38.0-W12.0_HS91L02W2C01.kicad_mod
@@ -90,8 +90,30 @@
 		(layer "F.SilkS")
 		(uuid "056afdbb-1ac8-4fcf-92a3-f7f96fb0ddb6")
 	)
+	(fp_circle
+		(center 34.25 -3.75)
+		(end 36 -3.75)
+		(stroke
+			(width 0.1)
+			(type default)
+		)
+		(fill no)
+		(layer "F.SilkS")
+		(uuid "123a4e37-5f8c-4867-a21a-f881869fac72")
+	)
+	(fp_circle
+		(center 34.25 3.75)
+		(end 36 3.75)
+		(stroke
+			(width 0.1)
+			(type default)
+		)
+		(fill no)
+		(layer "F.SilkS")
+		(uuid "e93f48db-dd20-4721-a33f-7b0c3a87d01d")
+	)
 	(fp_text user "1"
-		(at 1.66 5.68 0)
+		(at 1 3.75 0)
 		(layer "F.SilkS")
 		(uuid "35c2c2e6-1270-4813-95e4-665ba726a893")
 		(effects
@@ -112,6 +134,20 @@
 				(thickness 0.15)
 			)
 		)
+	)
+	(pad "" np_thru_hole circle
+		(at 34.25 -3.75)
+		(size 2 2)
+		(drill 2)
+		(layers "F&B.Cu" "*.Mask")
+		(uuid "9e02ea0b-fc44-4f8e-bd8a-9e5a6e0aa5b5")
+	)
+	(pad "" np_thru_hole circle
+		(at 34.25 3.75)
+		(size 2 2)
+		(drill 2)
+		(layers "F&B.Cu" "*.Mask")
+		(uuid "542b77f3-5200-45d1-a7ff-1b8c34b310cc")
 	)
 	(pad "1" thru_hole circle
 		(at 0 3.81)


### PR DESCRIPTION
They are deliberately not included in the PCB to reduce the potential of merge conflicts.